### PR TITLE
Added support for `.yaml` for nested includes.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export function createIncludeType({
   // Allow including other YAML files if we can create a nested schema
   if (createNestedSchema) {
     extensions.push({
-      pattern: /\.yml$/,
+      pattern: /\.ya?ml$/,
       construct: path => {
         const nestedType = createIncludeType({
           name,


### PR DESCRIPTION
This PR adds support for the `.yaml` extension by default.

I didn't add any test as this doesn't fail any existing tests, and changing `deepInclude.yml` to `deepInclude.yaml` and updating the include in `include.yml` doesn't fail the tests.

If you'd like me to add an explicit test/include for this I can.