### PR TITLE
Move js-yaml to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "typescript": "^3"
   },
   "dependencies": {
-    "datauri": "^2.0.0",
-    "js-yaml": "^3.13.1"
+    "datauri": "^2.0.0"
   },
   "config": {
     "commitizen": {
@@ -56,5 +55,8 @@
       "post-rewrite": "yarn install",
       "pre-commit": "pretty-quick --staged --verbose"
     }
+  },
+  "peerDependencies": {
+    "js-yaml": ">=3 <=4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,6 +409,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1924,7 +1929,14 @@ jest@^24.7.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.13.0, js-yaml@^3.13.1:
+"js-yaml@>=3 <=4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^3.13.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/jaulz/js-yaml-type-include/issues/11

This _does_ seem to fix the issue for me. I realize this type _does_ actually use `js-yaml`, so I'm not sure this is ideal, but it's the only option I can think of.

Here's the [relevant `js-yaml` validation](https://github.com/nodeca/js-yaml/blob/4.1.0/lib/schema.js#L103-L105) for context.